### PR TITLE
Preventing changes to session id save

### DIFF
--- a/lib/src/adcio_core.dart
+++ b/lib/src/adcio_core.dart
@@ -99,7 +99,7 @@ class AdcioCore {
     _clientId = clientId;
     _storeId = _clientId;
     _deviceId = deviceId ?? defaultDeviceId;
-    _sessionId = sessionId ?? _sessionId ?? const Uuid().v4();
+    _sessionId = sessionId ?? (_sessionId ?? const Uuid().v4());
 
     _isInitialized = true;
   }

--- a/lib/src/adcio_core.dart
+++ b/lib/src/adcio_core.dart
@@ -99,7 +99,7 @@ class AdcioCore {
     _clientId = clientId;
     _storeId = _clientId;
     _deviceId = deviceId ?? defaultDeviceId;
-    _sessionId = sessionId ?? const Uuid().v4();
+    _sessionId = sessionId ?? _sessionId ?? const Uuid().v4();
 
     _isInitialized = true;
   }

--- a/test/adcio_core_test.dart
+++ b/test/adcio_core_test.dart
@@ -105,4 +105,24 @@ void main() async {
     expect(AdcioCore.sessionId, isNot(equals(oldSampleSessionId)));
     expect(AdcioCore.sessionId, equals(newSampleSessionId));
   });
+
+  test(
+      'SessionId should not change if initializeApp function is called multiple times',
+      () async {
+    // set
+    await AdcioCore.initializeApp(
+      clientId: sampleClientId,
+    );
+
+    final oldSampleSessionId = AdcioCore.sessionId;
+
+    // use setter
+    await AdcioCore.initializeApp(
+      clientId: sampleClientId,
+    );
+
+    final newSampleSessionId = AdcioCore.sessionId;
+
+    expect(oldSampleSessionId, equals(newSampleSessionId));
+  });
 }


### PR DESCRIPTION
## :pushpin: Type of PR
feature + test
<!-- _Bugfix, Feature, Code style update (formatting, local variables), Refactoring (no functional changes, no api changes), Build related changes, CI related changes, Other..._  -->

## :recycle: Current situation
* App runtime 동안 initializeApp() 함수가 호출될 때마다 sessionId가 변경됨.

## :bulb: Proposed solution
* a7cc1b1e491bc31c62759be98cca0a25e264f4bf: 파라미터로 받은 sessionId가 null, 기본 _sessionId가 null이 아닐 경우(기존에 등록된 값이 있고 사용자 set 요청이 아닐 경우) 새로운 값을 Uuid를 통해서 할당하지 않음.
* 9d79b8fb38e0ad3519251424dffaab8d066e1ab4: test code 작성 (자세한 내용은 아래 작성)

## test
* desc : 'SessionId should not change if initializeApp function is called multiple times'
* 검증 순서
1. 기본 값(clientId)만으로 initializeApp 호출.
2. 자동으로 생성된 sessionId를 oldSampleSessionId에 저장.
3. 기본 값(clientId)만으로 initializeApp 다시 호출.
4. newSampleSessionId에 sessionId를 저장.
5. old, new SampleSesssionId 값은 같아야만 함.

## Exception 로직이 아닌 이유
https://www.notion.so/corcaai/initializeApp-1a37ae5e59664a2389b4331bd203bbf8?pvs=4

